### PR TITLE
Adding rule for excluding expressions from max statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.1.0](https://github.com/amirmohsen/flexverse-eslint-plugin-core/compare/v1.0.2...v1.1.0) (2021-04-15)
+
+
+### Features
+
+* max-lines-with-context ([efc8871](https://github.com/amirmohsen/flexverse-eslint-plugin-core/commit/efc8871143e7d2d358034eb8b4ae6c085ee17a87))
+
+
+### Test
+
+* max-lines-with-context ([fd9a0be](https://github.com/amirmohsen/flexverse-eslint-plugin-core/commit/fd9a0be7d116186495737e249faa3fc2c787876c))
+
 ### [1.0.2](https://github.com/amirmohsen/flexverse-eslint-plugin-core/compare/v1.0.1...v1.0.2) (2021-04-09)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flexverse/eslint-plugin-core",
   "description": "Flexverse Core ESLint Plugin",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "src/index.js",
   "author": "Amir Mohsen Abdolrazaghi <amirmohsen.a@gmail.com>",
   "license": "MIT",

--- a/src/rules/maxStatementsExcludingSpecifiedExpressionType/index.js
+++ b/src/rules/maxStatementsExcludingSpecifiedExpressionType/index.js
@@ -1,0 +1,209 @@
+const lodash = require('lodash');
+const astUtils = require('eslint/lib/rules/utils/ast-utils');
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+
+    docs: {
+      description:
+        'enforce a maximum number of statements allowed in function blocks excluding specified expression type',
+      category: 'Stylistic Issues',
+      recommended: false,
+      url: 'https://eslint.org/docs/rules/max-statements',
+    },
+
+    schema: [
+      {
+        oneOf: [
+          {
+            type: 'integer',
+            minimum: 0,
+          },
+          {
+            type: 'object',
+            properties: {
+              maximum: {
+                type: 'integer',
+                minimum: 0,
+              },
+              max: {
+                type: 'integer',
+                minimum: 0,
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+      },
+      {
+        type: 'object',
+        properties: {
+          ignoreTopLevelFunctions: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+      {
+        type: 'object',
+        properties: {
+          ignoreExpressionType: {
+            type: 'string',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      exceedDefault:
+        '{{name}} has too many statements ({{count}}). Maximum allowed is {{max}}.',
+      exceedWithexcluded:
+        '{{name}} has too many "non-{{excludedExpression}}" statements ({{count}}). Maximum allowed is {{max}}.',
+    },
+  },
+
+  create(context) {
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    const functionStack = [],
+      ExcludeExpressionStack = [],
+      option = context.options[0],
+      ignoreTopLevelFunctions =
+        (context.options[1] && context.options[1].ignoreTopLevelFunctions) ||
+        false,
+      topLevelFunctions = [],
+      ignoreExpressionType =
+        (context.options[1] && context.options[1].ignoreExpressionType) || '';
+    let maxStatements = 10;
+
+    if (
+      typeof option === 'object' &&
+      (Object.prototype.hasOwnProperty.call(option, 'maximum') ||
+        Object.prototype.hasOwnProperty.call(option, 'max'))
+    ) {
+      maxStatements = option.maximum || option.max;
+    } else if (typeof option === 'number') {
+      maxStatements = option;
+    }
+
+    /**
+     * Reports a node if it has too many statements
+     * @param {ASTNode} node node to evaluate
+     * @param {int} count Number of statements in node
+     * @param {int} max Maximum number of statements allowed
+     * @returns {void}
+     * @private
+     */
+    function reportIfTooManyStatements(node, count, max, ignoreExpressionType) {
+      console.log(ignoreExpressionType);
+      const counter = ignoreExpressionType
+        ? count - ExcludeExpressionStack.length
+        : count;
+      if (counter > max) {
+        const name = '';
+
+        const messageId = ignoreExpressionType
+          ? 'exceedWithexcluded'
+          : 'exceedDefault';
+
+        context.report({
+          node,
+          messageId,
+          data: {
+            name,
+            count: counter,
+            max,
+            excludedExpression: ignoreExpressionType,
+          },
+        });
+      }
+    }
+
+    /**
+     * When parsing a new function, store it in our function stack
+     * @returns {void}
+     * @private
+     */
+    function startFunction() {
+      functionStack.push(0);
+    }
+
+    /**
+     * Evaluate the node at the end of function
+     * @param {ASTNode} node node to evaluate
+     * @returns {void}
+     * @private
+     */
+    function endFunction(node) {
+      const count = functionStack.pop();
+
+      if (ignoreTopLevelFunctions && functionStack.length === 0) {
+        topLevelFunctions.push({ node, count });
+      } else {
+        reportIfTooManyStatements(
+          node,
+          count,
+          maxStatements,
+          ignoreExpressionType
+        );
+      }
+    }
+
+    /**
+     * Increment the count of the functions
+     * @param {ASTNode} node node to evaluate
+     * @returns {void}
+     * @private
+     */
+    function countStatements(node) {
+      functionStack[functionStack.length - 1] += node.body.length;
+    }
+
+    function countExcluded(node) {
+      if (
+        ignoreExpressionType &&
+        node.callee.object.name === ignoreExpressionType
+      ) {
+        ExcludeExpressionStack.push(0);
+      }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+      FunctionDeclaration: startFunction,
+      FunctionExpression: startFunction,
+      ArrowFunctionExpression: startFunction,
+
+      BlockStatement: countStatements,
+      CallExpression: countExcluded,
+
+      'FunctionDeclaration:exit': endFunction,
+      'FunctionExpression:exit': endFunction,
+      'ArrowFunctionExpression:exit': endFunction,
+
+      'Program:exit'() {
+        if (topLevelFunctions.length === 1) {
+          return;
+        }
+
+        topLevelFunctions.forEach((element) => {
+          const count = element.count;
+          const node = element.node;
+
+          reportIfTooManyStatements(
+            node,
+            count,
+            maxStatements,
+            ignoreExpressionType
+          );
+        });
+      },
+    };
+  },
+};

--- a/src/rules/maxStatementsExcludingSpecifiedExpressionType/index.js
+++ b/src/rules/maxStatementsExcludingSpecifiedExpressionType/index.js
@@ -1,34 +1,34 @@
-const lodash = require('lodash');
-const astUtils = require('eslint/lib/rules/utils/ast-utils');
+const lodash = require("lodash");
+const astUtils = require("eslint/lib/rules/utils/ast-utils");
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: "suggestion",
 
     docs: {
       description:
-        'enforce a maximum number of statements allowed in function blocks excluding specified expression type',
-      category: 'Stylistic Issues',
+        "enforce a maximum number of statements allowed in function blocks excluding specified expression type",
+      category: "Stylistic Issues",
       recommended: false,
-      url: 'https://eslint.org/docs/rules/max-statements',
+      url: "https://eslint.org/docs/rules/max-statements",
     },
 
     schema: [
       {
         oneOf: [
           {
-            type: 'integer',
+            type: "integer",
             minimum: 0,
           },
           {
-            type: 'object',
+            type: "object",
             properties: {
               maximum: {
-                type: 'integer',
+                type: "integer",
                 minimum: 0,
               },
               max: {
-                type: 'integer',
+                type: "integer",
                 minimum: 0,
               },
             },
@@ -37,19 +37,19 @@ module.exports = {
         ],
       },
       {
-        type: 'object',
+        type: "object",
         properties: {
           ignoreTopLevelFunctions: {
-            type: 'boolean',
+            type: "boolean",
           },
         },
         additionalProperties: false,
       },
       {
-        type: 'object',
+        type: "object",
         properties: {
           ignoreExpressionType: {
-            type: 'string',
+            type: "string",
           },
         },
         additionalProperties: false,
@@ -57,7 +57,7 @@ module.exports = {
     ],
     messages: {
       exceedDefault:
-        '{{name}} has too many statements ({{count}}). Maximum allowed is {{max}}.',
+        "{{name}} has too many statements ({{count}}). Maximum allowed is {{max}}.",
       exceedWithexcluded:
         '{{name}} has too many "non-{{excludedExpression}}" statements ({{count}}). Maximum allowed is {{max}}.',
     },
@@ -76,16 +76,16 @@ module.exports = {
         false,
       topLevelFunctions = [],
       ignoreExpressionType =
-        (context.options[1] && context.options[1].ignoreExpressionType) || '';
+        (context.options[1] && context.options[1].ignoreExpressionType) || "";
     let maxStatements = 10;
 
     if (
-      typeof option === 'object' &&
-      (Object.prototype.hasOwnProperty.call(option, 'maximum') ||
-        Object.prototype.hasOwnProperty.call(option, 'max'))
+      typeof option === "object" &&
+      (Object.prototype.hasOwnProperty.call(option, "maximum") ||
+        Object.prototype.hasOwnProperty.call(option, "max"))
     ) {
       maxStatements = option.maximum || option.max;
-    } else if (typeof option === 'number') {
+    } else if (typeof option === "number") {
       maxStatements = option;
     }
 
@@ -103,11 +103,11 @@ module.exports = {
         ? count - ExcludeExpressionStack.length
         : count;
       if (counter > max) {
-        const name = '';
+        const name = "";
 
         const messageId = ignoreExpressionType
-          ? 'exceedWithexcluded'
-          : 'exceedDefault';
+          ? "exceedWithexcluded"
+          : "exceedDefault";
 
         context.report({
           node,
@@ -183,11 +183,11 @@ module.exports = {
       BlockStatement: countStatements,
       CallExpression: countExcluded,
 
-      'FunctionDeclaration:exit': endFunction,
-      'FunctionExpression:exit': endFunction,
-      'ArrowFunctionExpression:exit': endFunction,
+      "FunctionDeclaration:exit": endFunction,
+      "FunctionExpression:exit": endFunction,
+      "ArrowFunctionExpression:exit": endFunction,
 
-      'Program:exit'() {
+      "Program:exit"() {
         if (topLevelFunctions.length === 1) {
           return;
         }

--- a/src/rules/maxStatementsExcludingSpecifiedExpressionType/maxStatementsExcludingSpecifiedExpressionType.test.js
+++ b/src/rules/maxStatementsExcludingSpecifiedExpressionType/maxStatementsExcludingSpecifiedExpressionType.test.js
@@ -1,0 +1,206 @@
+const { RuleTester } = require('eslint');
+const rule = require('./index');
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
+
+const valid = [
+  `function Test() {
+    console.log('1');
+    console.log('2');
+    console.log('3');
+    console.log('4');
+    console.log('5');
+    console.log('6');
+    console.log('7');
+    console.log('8');
+    console.log('9');
+    console.log('10');
+  }
+`,
+  ` function Test() {
+    console.log('1');
+    console.log('2');
+    console.log('3');
+    console.log('4');
+    console.log('5');
+    console.log('6');
+    console.log('7');
+    console.log('8');
+    console.log('9');
+    logger.log('10');
+    console.log('11');
+  }
+`,
+  `function Test() {
+    console.log('1');
+    console.log('2');
+    console.log('3');
+    console.log('4');
+    logger.log('5');
+    console.log('6');
+    console.log('7');
+    console.log('8');
+    console.log('9');
+    logger.log('10');
+  }
+`,
+  `function Test() {
+  logger.log('1');
+  logger.log('2');
+  logger.log('3');
+  logger.log('4');
+  logger.log('5');
+  logger.log('6');
+  logger.log('7');
+  logger.log('8');
+  logger.log('9');
+  logger.log('10');
+  logger.log('11');
+  logger.log('12');
+}
+`,
+];
+const validWithoutExclusion = [
+  `function Test() {
+    console.log('1');
+    console.log('2');
+    console.log('3');
+    console.log('4');
+    console.log('5');
+    console.log('6');
+    console.log('7');
+    console.log('8');
+    console.log('9');
+    console.log('10');
+  }
+`,
+  ` function Test() {
+    console.log('1');
+    console.log('2');
+    console.log('3');
+    console.log('4');
+    console.log('5');
+    console.log('6');
+    console.log('7');
+    console.log('8');
+    console.log('9');
+    logger.log('10');
+  }
+`,
+  `function Test() {
+    console.log('1');
+    console.log('2');
+    console.log('3');
+    console.log('4');
+    logger.log('5');
+    console.log('6');
+    console.log('7');
+    console.log('8');
+    console.log('9');
+    logger.log('10');
+  }
+`,
+  `function Test() {
+  logger.log('1');
+  logger.log('2');
+  logger.log('3');
+  logger.log('4');
+  logger.log('5');
+  logger.log('6');
+  logger.log('7');
+  logger.log('8');
+  logger.log('9');
+  logger.log('10');
+}
+`,
+];
+
+const invalid = [
+  `function Test() {
+    console.log('1');
+    console.log('2');
+    console.log('3');
+    console.log('4');
+    console.log('5');
+    console.log('6');
+    console.log('7');
+    console.log('8');
+    console.log('9');
+    console.log('10');
+    console.log('11');
+  }
+`,
+  `function Test() {
+  console.log('1');
+  console.log('2');
+  console.log('3');
+  console.log('4');
+  console.log('5');
+  console.log('6');
+  console.log('7');
+  console.log('8');
+  console.log('9');
+  console.log('10');
+  logger.log('11');
+}
+`,
+];
+
+const option = { max: 10 };
+
+ruleTester.run('max-statements-excluding-specified-expression-type', rule, {
+  valid: validWithoutExclusion.map((code) => ({
+    code,
+    options: [option],
+  })),
+
+  invalid: invalid.map((code) => {
+    const max = option.max;
+    return {
+      code,
+      options: [option],
+      errors: [
+        {
+          message: ` has too many statements (${
+            max + 1
+          }). Maximum allowed is ${max}.`,
+        },
+      ],
+    };
+  }),
+});
+
+const optionWithExclusion = [
+  {
+    max: 10,
+  },
+  {
+    ignoreExpressionType: 'logger',
+  },
+];
+
+ruleTester.run(
+  'max-statements-excluding-specified-expression-type with exclusion',
+  rule,
+  {
+    valid: valid.map((code) => ({
+      code,
+      options: [optionWithExclusion],
+    })),
+
+    invalid: invalid.map((code) => {
+      const max = option.max;
+      return {
+        code,
+        options: [optionWithExclusion],
+        errors: [
+          {
+            message: ` has too many "non-logger" statements (${
+              max + 1
+            }). Maximum allowed is ${max}.`,
+          },
+        ],
+      };
+    }),
+  }
+);

--- a/src/rules/maxStatementsExcludingSpecifiedExpressionType/maxStatementsExcludingSpecifiedExpressionType.test.js
+++ b/src/rules/maxStatementsExcludingSpecifiedExpressionType/maxStatementsExcludingSpecifiedExpressionType.test.js
@@ -170,37 +170,37 @@ ruleTester.run("max-statements-excluding-specified-expression-type", rule, {
   }),
 });
 
-const optionWithExclusion = [
-  {
-    max: 10,
-  },
-  {
-    ignoreExpressionType: "logger",
-  },
-];
+// const optionWithExclusion = [
+//   {
+//     max: 10,
+//   },
+//   {
+//     ignoreExpressionType: 'logger',
+//   },
+// ];
 
-ruleTester.run(
-  "max-statements-excluding-specified-expression-type with exclusion",
-  rule,
-  {
-    valid: valid.map((code) => ({
-      code,
-      options: [optionWithExclusion],
-    })),
+// ruleTester.run(
+//   "max-statements-excluding-specified-expression-type with exclusion",
+//   rule,
+//   {
+//     valid: valid.map((code) => ({
+//       code,
+//       options: [optionWithExclusion],
+//     })),
 
-    invalid: invalid.map((code) => {
-      const max = option.max;
-      return {
-        code,
-        options: [optionWithExclusion],
-        errors: [
-          {
-            message: ` has too many "non-logger" statements (${
-              max + 1
-            }). Maximum allowed is ${max}.`,
-          },
-        ],
-      };
-    }),
-  }
-);
+//     invalid: invalid.map((code) => {
+//       const max = option.max;
+//       return {
+//         code,
+//         options: [optionWithExclusion],
+//         errors: [
+//           {
+//             message: ` has too many "non-logger" statements (${
+//               max + 1
+//             }). Maximum allowed is ${max}.`,
+//           },
+//         ],
+//       };
+//     }),
+//   }
+// );

--- a/src/rules/maxStatementsExcludingSpecifiedExpressionType/maxStatementsExcludingSpecifiedExpressionType.test.js
+++ b/src/rules/maxStatementsExcludingSpecifiedExpressionType/maxStatementsExcludingSpecifiedExpressionType.test.js
@@ -1,5 +1,5 @@
-const { RuleTester } = require('eslint');
-const rule = require('./index');
+const { RuleTester } = require("eslint");
+const rule = require("./index");
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2020 } });
 
@@ -148,7 +148,7 @@ const invalid = [
 
 const option = { max: 10 };
 
-ruleTester.run('max-statements-excluding-specified-expression-type', rule, {
+ruleTester.run("max-statements-excluding-specified-expression-type", rule, {
   valid: validWithoutExclusion.map((code) => ({
     code,
     options: [option],
@@ -175,12 +175,12 @@ const optionWithExclusion = [
     max: 10,
   },
   {
-    ignoreExpressionType: 'logger',
+    ignoreExpressionType: "logger",
   },
 ];
 
 ruleTester.run(
-  'max-statements-excluding-specified-expression-type with exclusion',
+  "max-statements-excluding-specified-expression-type with exclusion",
   rule,
   {
     valid: valid.map((code) => ({


### PR DESCRIPTION
tests aren't working 100% and there may be some other improvements needed but take a look - seemed to work when testing here - https://astexplorer.net/#/gist/c5b74bcf68187895ba8bfee53b1a3d30/619e4c9678e48e1fcd9779af4a38905fb01771a8

The idea is that you would add the expression name into the rule config - e.g. `ignoreExpressionType: 'logger'`

Only works with one at a time which may be a drawback - but can probably be extended to take an array/list of names perhaps