### PR TITLE
fix: exporting max statements with exclusions rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ module.exports = {
   rules: {
     "max-lines-with-context": require("./rules/maxLinesWithContext"),
     "max-lines-per-function-body": require("./rules/maxLintsPerFunctionBody"),
+    "max-statements-with-exclusions": require("./rules/maxStatementsWithExclusions"),
   },
 };


### PR DESCRIPTION
Adding the new rule to the exports as it was missed